### PR TITLE
Fix clipboard cleanup

### DIFF
--- a/script.js
+++ b/script.js
@@ -158,7 +158,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 textarea.select();
                 try {
                     document.execCommand('copy');
-                    document.body.removeChild(textarea);
                     alert('Template copied to clipboard!');
                 } catch (err) {
                     console.error('Failed to copy text: ', err);


### PR DESCRIPTION
## Summary
- remove duplicate DOM removal call when copying template to clipboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68415b7c795c832297dd30e676c304c3